### PR TITLE
ENH: Adds ability to run http server; updates datalad

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python=3.8.*
   - pip
-  - datalad=0.15.*
+  - datalad=0.16.*
   - pip:
       - nbgitpuller
       - bash_kernel

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
       - nbgitpuller
       - bash_kernel
       - jupyter-notebookparams
+      - jupyter-server-proxy

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,12 @@
+# This is sh (dash) by default, not $SHELL
+c.NotebookApp.terminado_settings = { "shell_command": ["bash"] }
+
+c.ServerProxy.servers = {
+  'http-server': {
+    'command': ['python3', '-m', 'http.server', '{port}'],
+    'absolute_url': False,
+    'launcher_entry': {
+      'title': "HTTP Server"
+    }
+  }
+}


### PR DESCRIPTION
- Uses https://github.com/jupyterhub/jupyter-server-proxy for server, which adds a launch button for an http server, e.g. to view localhost content
- Closes https://github.com/datalad/datalad-binder/issues/6